### PR TITLE
Use HA as the time source

### DIFF
--- a/settings.h
+++ b/settings.h
@@ -44,7 +44,7 @@ String bearerToken = "<my bearer token string goes here - check the link above t
 
 #define SOLAR_PANELS true // Change to true if using solar panels, and add the sensor below.
 #define SENSOR_CURRENT_PRODUCTION "sensor.momentary_active_export" // If using ESPHome HAN port reader  https://github.com/psvanstrom/esphome-p1reader
-
+#define SENSOR_TIME "sensor.time" // Current local time, set up with https://www.home-assistant.io/integrations/time_date/
 
 // Home assistant
 char ssid[] = "<my ssid>";       // your network SSID (name)


### PR DESCRIPTION
Thanks a lot for fun and practical project! 

Here is a change that uses the time on Home Assistant (instead of NTP). Hopefully HA is in sync and also handles daylight savings time.

To enable, you need to add this to `configuration.yaml`

    sensor:
      - platform: time_date
        display_options:
          - "time"

The name of the sensor can be configured in `settings.h` by changing `SENSOR_TIME`.
